### PR TITLE
Better onboarding experience in `url/getting-started`

### DIFF
--- a/docs/url/getting-started.md
+++ b/docs/url/getting-started.md
@@ -5,12 +5,19 @@ description: >
     so that you can work with us. We can't wait to see what you do here!
 last_update:
     author: Carlos Valdez
-    date: April 2 2024
+    date: April 19 2024
 ---
 # Welcome to the Ojos Project
 
+<!-- ! NOTE FOR DEVELOPERS: -->
+<!-- ! Change the `last_update.author` and `last_update.date` value every time you edit. -->
+
 We're pleased that you decided to join us. There's a few things we need you to
 do to get started. ✨
+
+## Introduction
+
+<!-- todo: The Introduction section will be for tackling most of the onboarding problems. -->
 
 ## Understand the Structure
 

--- a/docs/url/getting-started.md
+++ b/docs/url/getting-started.md
@@ -18,7 +18,8 @@ do to get started. ✨
 ## About the Ojos Project
 
 Before we get you set up to work with us, read this section to learn more about
-the Ojos Project as well as who we are.
+the Ojos Project as well as who we are. Otherwise, if you just want to get
+setup, [you can go to the setup section](#setup).
 
 <!-- todo: The "About the Ojos Project" section will be for tackling most of the onboarding problems. -->
 
@@ -116,29 +117,50 @@ the software architecture of Iris.
 
 <!-- todo: Everything below needs to be modified a little bit. -->
 
-## Understand the Structure
+## Setup
+
+Now that you have a general background of the Ojos Project, let's get you set
+up!
+
+### Understand the Structure
 
 The Ojos Project runs under a "group, team, member" structure. You are
 participating in the URL Group. [Read the policies about that here if
 you're interested](/policies/structure/).
 
-## Figure out your commitment
+In short, a group in the Ojos Project works on a project. A team in a group
+works on a specific part of that project, such as development or engineering. A
+member is someone who is a member of a team.
 
-Some students in this research project are enrolled in IN4MATX 199 at UCI. Read
-the [IN4MATX 199 Acknowledgement](/policies/inf199-acknowledgement) to learn
-more.
+The URL Group has two teams: [Developers](/url/developers/) and
+[Engineering](/url/engineering/).
 
-**If you are enrolled in IN4MATX 199, you are required to participate for a
-minimum of two quarters.**
+Both groups and teams have leads.
+
+| Group/Team       | Lead          |
+| ---------------- | ------------- |
+| URL Group        | Carlos Valdez |
+| Developers team  | Carlos Valdez |
+| Engineering team | Joseph Sweatt |
+
+As a member, you report to your team lead, and team leads report to the group
+lead.
+
+### Figure out your commitment
+
+Some students in this research project are enrolled in IN4MATX 199 at UCI,
+**but new members are not able to enroll**. Read the
+[IN4MATX 199 Acknowledgement](/policies/inf199-acknowledgement) to learn more.
 
 If you are not enrolled in IN4MATX 199, you may join and leave the project as
-you'd like, with limits. Read
-[Getting recognized as a member](#getting-recognized-as-a-member) below to learn
-more.
+you'd like, with limits. The limits are: 1) Your attendance must be documented,
+and 2) If you go AWOL for 2 weeks, we will assume you dropped the project. Read
+[our attendance policies](/policies/url-lab-attendance/) to learn more.
 
-## Add meetings to your calendar
+### Add meetings to your calendar
 
-We also have other meetings, but that depends on the team you are in.
+We meet on a regular basis. This is our meeting times for the 2024 Spring
+quarter:
 
 | Team             | Meeting              | Location | Description         |
 | ---------------- | -------------------- | -------- | ------------------- |
@@ -156,18 +178,18 @@ heading.
 
 :::
 
-## Join our Google Drive
+### Join our Google Drive
 
 We have an
 [internal Google Drive](https://drive.google.com/drive/folders/1nsghXOEXTWsKTtgMzlCuXMp8iIiq8iBb)
 that hosts some important files we use. It'll be helpful to join that!
 
-## Join our Slack workspace
+### Join our Slack workspace
 
 We have a [Slack workspace](https://ojosproject.slack.com) that we use to
 communicate with each other. Please join!
 
-## Send us your email
+### Send us your email
 
 A lot of the stuff we do will require email addresses. We require that you send
 us an email that is associated with your institution. The following are the
@@ -187,25 +209,31 @@ That is, it must end with `.edu`.
 
 :::
 
-## Send Carlos your portfolio/website
+### Send Carlos a website
 
 We promote your website on [our main page](https://ojosproject.org/#team) and on
 [the members page](/url/members/). Send Carlos your website to add the link!
 
 :::tip
 
-It doesn't have to be a personal website. It can be your social media, or
-anywhere you want people to contact you.
+It doesn't have to be a personal website. Examples we suggest are:
+
+- Portfolio
+- Email
+- LinkedIn
+- ... anything else you may want recruiters to see
 
 :::
 
-## Set up your Gravatar
+### Set up your Gravatar
 
-A lot of the services we use integrates [Gravatar](https://gravatar.com/). It
-adds an icon to your email. To learn more about getting that up, please check
-out [this guide](/url/developers/guides/gravatar).
+A lot of the services we use integrate [Gravatar](https://gravatar.com/). It's
+important to have one set as it gives an avatar to your name on our website. To
+learn more about getting that up, please check out
+[this guide](/url/developers/guides/gravatar). All you have to do is create a
+Gravatar account and set a photo. That's it!
 
-## Getting recognized as a member
+### Getting recognized as a member
 
 :::tip
 
@@ -217,7 +245,8 @@ member.
 To get recognized as a member, you must contribute to the project in some way.
 That may mean writing research notes, adding a commit message to any of our git
 repos, etc. As long as we see you are dedicated to the project, you may get
-recognized as a member if you so wish.
+recognized as a member if you so wish. To remain an active member, you must
+comply with our [attendance policies](/policies/url-lab-attendance/).
 
 Benefits include...
 
@@ -226,7 +255,7 @@ Benefits include...
 3. Getting vouched for by Carlos if you need a reference
 4. Probably more that I can't think of right now
 
-## What's next?
+### What's next?
 
 There may be more instructions depending on the team you're in. Read the
 instructions for the team you are in:
@@ -243,5 +272,6 @@ This checklist is here for the people helping you get set up.
 - [ ] Give access to the Google Drive
 - [ ] Give access to Slack
 - [ ] Ensure we have their email
+- [ ] Ask which link to promote
 - [ ] Ensure their Gravatar is set
 - [ ] Check if they automatically are a recognized member

--- a/docs/url/getting-started.md
+++ b/docs/url/getting-started.md
@@ -5,7 +5,7 @@ description: >
     so that you can work with us. We can't wait to see what you do here!
 last_update:
     author: Carlos Valdez
-    date: April 19 2024
+    date: April 21 2024
 ---
 # Welcome to the Ojos Project
 
@@ -15,9 +15,104 @@ last_update:
 We're pleased that you decided to join us. There's a few things we need you to
 do to get started. ✨
 
-## Introduction
+## About the Ojos Project
 
-<!-- todo: The Introduction section will be for tackling most of the onboarding problems. -->
+Before we get you set up to work with us, read this section to learn more about
+the Ojos Project as well as who we are.
+
+<!-- todo: The "About the Ojos Project" section will be for tackling most of the onboarding problems. -->
+
+### Background
+
+Carlos Valdez is an Informatics undergraduate at the University of California,
+Irvine. In July 2022, Carlos' grandma was placed in hospice because her cancer
+was too advanced. Since this was during the summer, Carlos spent most of his
+time taking care of her. While his mom and grandpa were working, he'd give her
+medications, food, and overall ensure she was okay. Once his grandpa would come
+home from work, he'd take over the care. This was the cycle for most weekdays
+until August 17 when she had passed away. During this time, he had witnessed
+critical shortcomings in hospice. Miscommunication between caregivers and
+difficulty in communicating with hospice nurses were a big issue.
+
+Professor Mark Baldwin is a professor at UCI in the department of Informatics.
+He has a background in accessibility and assistive technologies and persued a
+Ph.D. to make an impact in this field. During the summer of 2023, Carlos had
+emailed Professor Mark Baldwin about potential research opportunities. During
+this time, the professor was about to take research proposals for the
+Undergraduate Research Lab, so it was perfect timing for both parties.
+[Carlos submitted this proposal](/url/proposal/) to the professor, and after a
+few more emails and a meeting, we got to work on the (soon to be named) Ojos
+Project.
+
+<!-- todo: Joseph should probably add a section here for himself since he was part of Ojos for just about the same time. -->
+
+Since the Ojos Project started in October 2023, many more members have joined.
+[View all the members here](/url/members/).
+
+### What is hospice care?
+
+Hospice care is a type of care that focuses on a person's comfort as they're
+approaching the end of their life. People are usually placed in hospice care if
+their illness cannot be cured.
+
+Palliative care, on the other hand, may be similar to hospice care, however,
+people undergoing palliative care are still receiving treatment for their
+serious illness.
+
+You can learn more about both types of care from
+[this article from the National Institute of Health](https://www.nia.nih.gov/health/hospice-and-palliative-care/what-are-palliative-care-and-hospice-care).
+
+### Problems we identified
+
+Although hospice and palliative care focus on a patient's comfort, there's some
+aspects to it that can be improved. Through personal experiences and interviews
+we've conducted, we discovered aspects of palliative care that can be improved.
+
+Some of the problems we've identified are:
+
+- Miscommunication between caregivers
+- Caregivers not being able to be there due to work or financial reasons
+- Patients running the risk of being mistreated by hospice nurses
+- Patients forgetting to report their discomfort to nurses
+- ... and more
+
+### Our solutions
+
+Technology can't fix everything, but we can try.
+
+The goal of this project is to develop a device with our open-source software
+that does the following:
+
+- Document medications/care instructions
+- Providing financial resources to caregivers
+- Video monitoring the patient-nurse interactions to hold nurses accountable
+- Ensuring we document Patient Recorded Outcomes (PROs)
+- ... and more
+
+We're trying to develop two solutions: Iris, the open-source software that can
+do all of the above and be installable on any Linux distribution, and
+Palliview, a device that uses our software to provide a "plug and play"
+experience.
+
+:::tip
+
+If you want to get a deeper understanding of the solutions we came up with, you
+can view our
+[internal interview notes here](https://drive.google.com/drive/folders/1eIlEgCuRF6o4AtZqr3XAkX4-Ur-Y1uDr).
+These are notes from caregivers and healthcare professionals we've interviewed.
+
+We also have our
+[Requirements document](https://docs.google.com/document/d/1EJlghYqhiPrZsjPUHxxG_WeHkHulPB4a-HF8fL7QsCs/).
+A requirements document has all of the features our software should include, as
+well as shareholder concerns. It may be worth giving this document a read.
+
+We're also actively working
+[C4 Model diagrams](/url/developers/design/c4-model/), which visually depicts
+the software architecture of Iris.
+
+:::
+
+<!-- todo: Everything below needs to be modified a little bit. -->
 
 ## Understand the Structure
 

--- a/docs/url/getting-started.md
+++ b/docs/url/getting-started.md
@@ -5,7 +5,7 @@ description: >
     so that you can work with us. We can't wait to see what you do here!
 last_update:
     author: Carlos Valdez
-    date: April 21 2024
+    date: April 22 2024
 ---
 # Welcome to the Ojos Project
 
@@ -36,7 +36,7 @@ difficulty in communicating with hospice nurses were a big issue. In this
 project, Carlos is the lead of the [Developers team](/url/developers/).
 
 Professor Mark Baldwin is a professor at UCI in the department of Informatics.
-He has a background in accessibility and assistive technologies and persued a
+He has a background in accessibility and assistive technologies and pursued a
 Ph.D. to make an impact in this field. During the summer of 2023, Carlos had
 emailed Professor Mark Baldwin about potential research opportunities. During
 this time, the professor was about to take research proposals for the

--- a/docs/url/getting-started.md
+++ b/docs/url/getting-started.md
@@ -32,7 +32,8 @@ medications, food, and overall ensure she was okay. Once his grandpa would come
 home from work, he'd take over the care. This was the cycle for most weekdays
 until August 17 when she had passed away. During this time, he had witnessed
 critical shortcomings in hospice. Miscommunication between caregivers and
-difficulty in communicating with hospice nurses were a big issue.
+difficulty in communicating with hospice nurses were a big issue. In this
+project, Carlos is the lead of the [Developers team](/url/developers/).
 
 Professor Mark Baldwin is a professor at UCI in the department of Informatics.
 He has a background in accessibility and assistive technologies and persued a
@@ -42,7 +43,8 @@ this time, the professor was about to take research proposals for the
 Undergraduate Research Lab, so it was perfect timing for both parties.
 [Carlos submitted this proposal](/url/proposal/) to the professor, and after a
 few more emails and a meeting, we got to work on the (soon to be named) Ojos
-Project.
+Project. In this project, Professor Baldwin is our research advisor and faculty
+mentor.
 
 <!-- todo: Joseph should probably add a section here for himself since he was part of Ojos for just about the same time. -->
 

--- a/docs/url/getting-started.md
+++ b/docs/url/getting-started.md
@@ -9,9 +9,6 @@ last_update:
 ---
 # Welcome to the Ojos Project
 
-<!-- ! NOTE FOR DEVELOPERS: -->
-<!-- ! Change the `last_update.author` and `last_update.date` value every time you edit. -->
-
 We're pleased that you decided to join us. There's a few things we need you to
 do to get started. ✨
 
@@ -20,8 +17,6 @@ do to get started. ✨
 Before we get you set up to work with us, read this section to learn more about
 the Ojos Project as well as who we are. Otherwise, if you just want to get
 setup, [you can go to the setup section](#setup).
-
-<!-- todo: The "About the Ojos Project" section will be for tackling most of the onboarding problems. -->
 
 ### Background
 
@@ -114,8 +109,6 @@ We're also actively working
 the software architecture of Iris.
 
 :::
-
-<!-- todo: Everything below needs to be modified a little bit. -->
 
 ## Setup
 


### PR DESCRIPTION
# Why a rewrite?

The on-boarding experience in `url/getting-started` is less of onboard instructions and more of just a setup without proving any background to the project. This rewrite will improve on-boarding for future members.

Early thanks to @AyushJain2021 for bringing this up.

## Needed changes

- [ ] Introduce the actual project
  - [ ] Give background of the advisor, team leads, etc.
  - [x] Explain what hospice care is
  - [x] Explain the problems we identified in hospice
  - [x] Introduce the solutions we're trying to develop
- [x] Continue with the actual setup
  - [x] Technical stuff (calendar, emails, etc.)
  - [x] Bash/Debian/etc. setups
- [x] Provide supplemental material
  - [x] Interview notes
  - [x] Requirements
  - [x] Other stuff we might want to introduce them to

❓ See anything we're missing? Please add a comment below!

## Instructions for the Developers team

If you want to work on this, please run the following commands:

```shell
# If you haven't already, clone the repo
git clone git@github.com:ojosproject/docs.git

# Switch to this branch
git switch url/getting-started-rewrite
```

**All** commits must be done on the `url/getting-started-rewrite` branch in order to appear in this pull request.

If you have any questions, please comment below. Thanks!